### PR TITLE
Fix problem with amTimeAgo directive not working

### DIFF
--- a/lib/filters/amTimeAgo.js
+++ b/lib/filters/amTimeAgo.js
@@ -57,7 +57,7 @@ angular.module('gdi2290.amTimeAgo')
 
 
       scope.$watch(attrs.amTimeAgo, function (value) {
-        if (isUndefined) {
+        if (isUndefined(value)) {
           cancelTimer();
           if (currentValue) {
             element.text('');


### PR DESCRIPTION
This one simple if condition was cause of amTimeAgo directive not working properly. It cleared text of current element regarding of if value was undefined.
