### PR TITLE
Adding moment.js dependency to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "*"
+    "angular": "*",
+    "moment": "*"
   }
 }


### PR DESCRIPTION
Having moment.js listed as a dependency in bower.json allows bower tools for Grunt/Gulp to resolve dependencies correctly to injecting <script> tags into HTML in the correct order
